### PR TITLE
fix: remove deep imports to cucumber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ### Fixed
 
+* Replace `@cucumber/cucumber` deep imports with equivalents from main entry point
+
 ## [1.0.0-alpha.1](https://github.com/jbpros/cucumber-pretty-formatter/compare/v1.0.0-alpha.0...v1.0.0-alpha.1)
 
 ### Fixed

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,12 +4,6 @@ import {
   IFormatterOptions,
   formatterHelpers,
 } from '@cucumber/cucumber'
-import {
-  getGherkinExampleRuleMap,
-  getGherkinScenarioMap,
-  getGherkinStepMap,
-} from '@cucumber/cucumber/lib/formatter/helpers/gherkin_document_parser'
-import { getPickleStepMap } from '@cucumber/cucumber/lib/formatter/helpers/pickle_parser'
 import * as messages from '@cucumber/messages'
 import * as CliTable3 from 'cli-table3'
 import { cross, tick } from 'figures'
@@ -18,7 +12,13 @@ import dedent from 'ts-dedent'
 
 import { makeTheme, ThemeItem, ThemeStyles } from './theme'
 
-const { formatLocation } = formatterHelpers
+const { formatLocation, GherkinDocumentParser, PickleParser } = formatterHelpers
+const {
+  getGherkinExampleRuleMap,
+  getGherkinScenarioMap,
+  getGherkinStepMap,
+} = GherkinDocumentParser
+const { getPickleStepMap } = PickleParser
 
 const marks = {
   [Status.AMBIGUOUS]: cross,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,9 @@
-import { Status, SummaryFormatter } from '@cucumber/cucumber'
-import { IFormatterOptions } from '@cucumber/cucumber/lib/formatter'
-import { formatLocation } from '@cucumber/cucumber/lib/formatter/helpers'
+import {
+  Status,
+  SummaryFormatter,
+  IFormatterOptions,
+  formatterHelpers,
+} from '@cucumber/cucumber'
 import {
   getGherkinExampleRuleMap,
   getGherkinScenarioMap,
@@ -14,6 +17,8 @@ import { EOL as n } from 'os'
 import dedent from 'ts-dedent'
 
 import { makeTheme, ThemeItem, ThemeStyles } from './theme'
+
+const { formatLocation } = formatterHelpers
 
 const marks = {
   [Status.AMBIGUOUS]: cross,


### PR DESCRIPTION
<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most likely to make sense to other people when they are reviewing it. Still, it's just a guide, so feel free to delete anything that doesn't feel appropriate, and add anything additional that seems like it would probide useful context. 👏🏻
-->

### 🤔 What's changed?

Remove deep imports into `@cucumber/cucumber/lib/...`. All the required things are obtainable by unpacking things already on the main entry point - it's mostly the formatter helpers.

### ⚡️ What's your motivation? 

<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->

- Fixes #9
- Fixes #10

As the world moved to ESM, deep imports like this will no longer work. This fixes compatibility with the latest cucumber-js.

### What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

<!--- 
This is to help you remember all the little thing we often forget to do!

Go over all the following points, and put an `x` in all the boxes that apply.
-->

- [x] I have read the [**CONTRIBUTING**](../CONTRIBUTING.md) document.
- [ ] My change needed additional tests
  - [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.
