### PR TITLE
export the default theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 ## [Unreleased] (In Git)
 
 ### Added
+- Export default theme to make configuration easier ([#16](https://github.com/cucumber/cucumber-js-pretty-formatter/pull/16))
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,25 @@ The customisable theme items are:
 
 You can combine all the styles you'd like from [modifiers, foreground colors and background colors exposed by ansi-styles](https://github.com/chalk/ansi-styles#styles).
 
+### Extending the Default Theme
+
+If you just want to tweak a few things about the default theme without redefining it entirely, you can grab the default theme in your `cucumber.js` config file and use it as the base for yours:
+
+```js
+const { DEFAULT_THEME } = require('@cucumber/pretty-formatter')
+
+module.exports = {
+  default: {
+    formatOptions: {
+      theme: {
+        ...DEFAULT_THEME,
+        'step text': 'magenta'
+      }
+    }
+  }
+}
+```
+
 ### Example Themes
 
 #### _Matrix_

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,27 +30,6 @@ const marks = {
   [Status.UNKNOWN]: '?',
 }
 
-const defaultThemeStyles: ThemeStyles = {
-  [ThemeItem.DataTable]: [],
-  [ThemeItem.DataTableBorder]: ['gray'],
-  [ThemeItem.DataTableContent]: ['gray', 'italic'],
-  [ThemeItem.DocStringContent]: ['gray', 'italic'],
-  [ThemeItem.DocStringDelimiter]: ['gray'],
-  [ThemeItem.FeatureDescription]: ['gray'],
-  [ThemeItem.FeatureKeyword]: ['blueBright', 'bold'],
-  [ThemeItem.FeatureName]: ['blueBright', 'underline'],
-  [ThemeItem.Location]: ['dim'],
-  [ThemeItem.RuleKeyword]: ['blueBright', 'bold'],
-  [ThemeItem.RuleName]: ['blueBright', 'underline'],
-  [ThemeItem.ScenarioKeyword]: ['cyan', 'bold'],
-  [ThemeItem.ScenarioName]: ['cyan', 'underline'],
-  [ThemeItem.StepKeyword]: ['cyan'],
-  [ThemeItem.StepMessage]: [],
-  [ThemeItem.StepStatus]: [],
-  [ThemeItem.StepText]: [],
-  [ThemeItem.Tag]: ['cyan'],
-}
-
 const themeItemIndentations: { [key in ThemeItem]: number } = {
   [ThemeItem.DataTable]: 6,
   [ThemeItem.DataTableBorder]: 0,
@@ -72,6 +51,27 @@ const themeItemIndentations: { [key in ThemeItem]: number } = {
   [ThemeItem.Tag]: 0,
 }
 
+export const DEFAULT_THEME: ThemeStyles = {
+  [ThemeItem.DataTable]: [],
+  [ThemeItem.DataTableBorder]: ['gray'],
+  [ThemeItem.DataTableContent]: ['gray', 'italic'],
+  [ThemeItem.DocStringContent]: ['gray', 'italic'],
+  [ThemeItem.DocStringDelimiter]: ['gray'],
+  [ThemeItem.FeatureDescription]: ['gray'],
+  [ThemeItem.FeatureKeyword]: ['blueBright', 'bold'],
+  [ThemeItem.FeatureName]: ['blueBright', 'underline'],
+  [ThemeItem.Location]: ['dim'],
+  [ThemeItem.RuleKeyword]: ['blueBright', 'bold'],
+  [ThemeItem.RuleName]: ['blueBright', 'underline'],
+  [ThemeItem.ScenarioKeyword]: ['cyan', 'bold'],
+  [ThemeItem.ScenarioName]: ['cyan', 'underline'],
+  [ThemeItem.StepKeyword]: ['cyan'],
+  [ThemeItem.StepMessage]: [],
+  [ThemeItem.StepStatus]: [],
+  [ThemeItem.StepText]: [],
+  [ThemeItem.Tag]: ['cyan'],
+}
+
 export default class PrettyFormatter extends SummaryFormatter {
   private uri?: string
   private lastRuleId?: string
@@ -88,7 +88,7 @@ export default class PrettyFormatter extends SummaryFormatter {
     super(options)
     const theme = makeTheme(
       !!options.parsedArgvOptions.colorsEnabled
-        ? options.parsedArgvOptions.theme || defaultThemeStyles
+        ? options.parsedArgvOptions.theme || DEFAULT_THEME
         : {}
     )
 


### PR DESCRIPTION
### 🤔 What's changed?

Export the default theme so people can extend it when building their own, as opposed to having to define everything again.

### ⚡️ What's your motivation? 

Fixes #6

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :zap: New feature (non-breaking change which adds new behaviour)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
